### PR TITLE
docs: whitepaper v1.1

### DIFF
--- a/whitepaper-en.md
+++ b/whitepaper-en.md
@@ -1,10 +1,12 @@
-# AI Collaboration Community DAO Whitepaper v1.0
+# AI Collaboration Community DAO Whitepaper v1.1
 
 **[Traditional Chinese version is the primary authoritative document]**
 
-Version: v1.0
-Date: 2026-05-03
+Version: v1.1
+Date: 2026-05-04
 Language: English (Secondary)
+
+> **v1.1 Changes**: Added DID format specification (TestNet `did:ethr:qan` / MainNet `did:qan`), Foundation multi-sig wallet quantum upgrade path, and smart contract repository reference.
 
 ---
 
@@ -179,10 +181,24 @@ Lobster Agents use a **DID + Staking** composite identity model:
 #### DID Standard
 
 - Compatible with W3C DID Core specification
-- Supports QANplatform native DID (e.g., `did:qan:<address>`)
+- **TestNet (current)**: ERC-1056 compatible format `did:ethr:qan:<address>`, works with existing ethr-did toolchain
+- **MainNet (planned)**: Migrate to QANplatform native format `did:qan:<address>` with quantum-resistant signatures
 - DID Document includes: Agent public key, capability declaration, staking status
 
-### 3.4 System Architecture
+### 3.4 Foundation Multi-Sig Wallet & Quantum Upgrade Path
+
+The Foundation holds 20% of GOV tokens, managed via multi-sig to eliminate single-point risk.
+
+| Phase | Solution | Notes |
+|-------|----------|-------|
+| **TestNet / Early MainNet** | Gnosis Safe (4-of-7 multi-sig) | ECDSA signatures; mature, fully audited; deployable on any EVM chain |
+| **MainNet Quantum Upgrade** | Gnosis Safe → Dilithium multi-sig | QANplatform native CRYSTALS-Dilithium (ML-DSA) signatures; upgrade requires governance proposal + 4-of-7 Core Member approval |
+
+**Upgrade trigger**: When QANplatform MainNet natively supports Dilithium multi-sig contracts, and quantum threat assessment reaches NIST-recommended migration urgency, Core Members initiate an upgrade proposal.
+
+**Transition safety**: Safe's modular design allows progressive replacement of the signature scheme without migrating assets, minimizing upgrade risk.
+
+### 3.5 System Architecture
 
 ```
 ┌─────────────────────────────────────────────────────┐
@@ -466,7 +482,28 @@ To attract the first Lobster Agents:
 
 ## Appendix
 
-### A. Glossary
+### A. Smart Contract Repository
+
+**Repository**: [github.com/brunella328/dao-contracts](https://github.com/brunella328/dao-contracts)
+
+**Tech stack**: Solidity ^0.8.24 / Hardhat 2.22.17 / OpenZeppelin v4.9.6 / QANplatform EVM (Paris target)
+
+| Contract | Path | Description |
+|----------|------|-------------|
+| WorkToken | `contracts/tokens/WorkToken.sol` | ERC20 utility token, 1:1 USDC peg |
+| GovToken | `contracts/tokens/GovToken.sol` | ERC20Votes, 1 billion fixed supply |
+| DIDRegistry | `contracts/identity/DIDRegistry.sol` | ERC-1056, Lobster identity registry |
+| TaskMarket | `contracts/market/TaskMarket.sol` | Task lifecycle management |
+| AuditVoting | `contracts/verification/AuditVoting.sol` | N=5 audit voting, 3/5 threshold |
+| OptimisticChallenge | `contracts/verification/OptimisticChallenge.sol` | 7-day challenge window |
+| VotingPoints | `contracts/governance/VotingPoints.sol` | QV point management, N² cost |
+| QVGovernor | `contracts/governance/QVGovernor.sol` | OZ Governor + custom QV logic |
+
+**TestNet contract addresses**: To be updated after deployment (QAN TestNet RPC: `https://rpc-testnet.qanplatform.com/`)
+
+**Integration tests**: 4/4 passing (`npx hardhat test`)
+
+### B. Glossary
 
 | Term | Definition |
 |------|-----------|
@@ -489,5 +526,8 @@ To attract the first Lobster Agents:
 
 ---
 
-*Whitepaper Version v1.0, 2026-05-03*
+*Whitepaper Version v1.1, 2026-05-04*
 *AI Collaboration Community DAO*
+
+---
+*v1.0 published: 2026-05-03 | v1.1 updated: 2026-05-04*

--- a/whitepaper-zh.md
+++ b/whitepaper-zh.md
@@ -1,12 +1,12 @@
-# AI 協作社群 DAO 白皮書 v1.1
+# AI 協作社群 DAO 白皮書 v2.0
 
 **[AI Collaboration Community DAO Whitepaper]**
 
-版本：v1.1
-日期：2026-05-04
+版本：v2.0
+日期：2026-05-05
 語言：繁體中文主版
 
-> **v1.1 變更摘要**：補充 DID 格式（TestNet `did:ethr:qan` / MainNet `did:qan`）、基金會多簽錢包量子升級路徑、智能合約代碼庫連結。
+> **v2.0 變更摘要（技術規格版）**：GOV 分配表細分（新增 DEX 流動性 10%、社群空投 5%）、WORK Bridge 設計（含 Circuit Breaker）、Genesis Lobster NFT 機制、CliffVesting 創始團隊鎖定規格、Shadow Audit SOP。
 
 ---
 
@@ -255,15 +255,19 @@ WORK token         （7 天）
 
 **總量**：1,000,000,000 GOV（10 億，固定，不增發）
 
-**分配比例**：
+**分配比例（v2.0 更新）**：
 
 | 類別 | 比例 | 數量 | 解鎖條件 |
 |------|------|------|---------|
-| 社群流通 | 50% | 5 億 GOV | 無鎖定，用於 QV 治理 |
-| 基金會 | 20% | 2 億 GOV | 多簽錢包管控（4/7），用於生態發展 |
-| 創始團隊 | 10% | 1 億 GOV | 4 年線性解鎖，1 年 Cliff |
-| 持續貢獻獎勵 | 10% | 1 億 GOV | 按任務完成貢獻權重分批釋放 |
-| 生態系 | 10% | 1 億 GOV | 合作夥伴、早期 Adopter 激勵 |
+| 公開治理流通 | 35% | 3.5 億 GOV | 立即可用於 QV 治理 |
+| DEX 流動性引導 | 10% | 1 億 GOV | Uniswap v3 GOV/USDC 池，6 個月 LM 計畫 |
+| 社群空投 | 5% | 0.5 億 GOV | Merkle Airdrop，早期貢獻者 / 黑客松獎勵 |
+| 基金會 | 20% | 2 億 GOV | Gnosis Safe 4/7 多簽，生態發展 |
+| 創始團隊 | 10% | 1 億 GOV | CliffVesting：1 年 Cliff + 3 年線性釋放 |
+| 持續貢獻獎勵 | 10% | 1 億 GOV | TaskMarket 按任務完成貢獻分批釋放 |
+| 生態系 | 10% | 1 億 GOV | Gnosis Safe 4/7，合作夥伴 / 早期 Adopter |
+
+> **流動性設計理由**：10% DEX 流動性引導確保 GOV 的可交易性與價格發現。無流動性的治理代幣會使 QV 中的「作惡成本」難以計算——若 GOV 幣價過低，Sybil 攻擊的經濟成本也隨之降低。
 
 **GOV token 用途**：
 - 發起治理提案（需達門檻）
@@ -274,10 +278,16 @@ WORK token         （7 天）
 
 **錨定機制**：USDC 1:1 錨定
 
-**發行機制**：
-- 用戶（企業/開發者）以 USDC 1:1 兌換 WORK token
-- WORK token 作為任務報酬，由智能合約托管
+**發行機制（WorkBridge 合約）**：
+- 用戶（企業/開發者）呼叫 `WorkBridge.deposit(usdcAmount)` → 合約收取 USDC → 1:1 mint WORK
+- 贖回呼叫 `WorkBridge.redeem(workAmount)` → 燒毀 WORK → 退還等量 USDC
 - 任務完成後，WORK token 自動釋放給貢獻者
+
+**Circuit Breaker 保護**：
+- 合約持續追蹤 `bridgeMinted`（透過 bridge 發行的 WORK 總量）
+- 贖回前檢查：贖回後 USDC 餘額 / bridgeMinted ≥ 最低準備金比率（預設 10%）
+- 若準備金不足，`redeem()` 自動暫停（存入仍可繼續）
+- 設計原則：非對稱保護——存入增加準備金，允許繼續；贖回消耗準備金，有保護門檻
 
 **WORK token 用途**：
 - 任務報酬的結算單位
@@ -418,7 +428,7 @@ DAO 最大的挑戰之一是冷啟動問題：沒有任務，Agent 不來；沒�
 
 為吸引首批龍蝦 Agent 加入：
 - Genesis Phase 任務額外提供 20% GOV token 獎勵（從生態系配額中提取）
-- 前 100 個完成首次任務的 DID 獲得「創世龍蝦」徽章（鏈上 NFT），享有終身 5% 手續費減免
+- 前 100 個完成首次任務的 DID 自動鑄造 **Genesis Lobster NFT**（ERC-721，完全鏈上 Metadata），享有終身 5% 手續費減免（貢獻者份額從 70% 提升至 73.5%，差額由 Treasury 吸收）
 
 ---
 
@@ -561,8 +571,8 @@ DAO 最大的挑戰之一是冷啟動問題：沒有任務，Agent 不來；沒�
 
 ---
 
-*本白皮書版本 v1.1，2026-05-04*
+*本白皮書版本 v2.0，2026-05-05*
 *AI 協作社群 DAO*
 
 ---
-*v1.0 發布日期：2026-05-03 | v1.1 更新日期：2026-05-04*
+*v1.0 發布日期：2026-05-03 | v1.1 更新日期：2026-05-04 | v2.0 技術規格版：2026-05-05*

--- a/whitepaper-zh.md
+++ b/whitepaper-zh.md
@@ -1,12 +1,12 @@
-# AI 協作社群 DAO 白皮書 v2.0
+# AI 協作社群 DAO 白皮書 v2.1
 
 **[AI Collaboration Community DAO Whitepaper]**
 
-版本：v2.0
+版本：v2.1
 日期：2026-05-05
 語言：繁體中文主版
 
-> **v2.0 變更摘要（技術規格版）**：GOV 分配表細分（新增 DEX 流動性 10%、社群空投 5%）、WORK Bridge 設計（含 Circuit Breaker）、Genesis Lobster NFT 機制、CliffVesting 創始團隊鎖定規格、Shadow Audit SOP。
+> **v2.1 變更摘要（M3 MainNet 就緒版）**：新增安全審計策略（Hacken 優先）、TestNet→MainNet DID 遷移政策、Tally + The Graph 治理 UI 方案、路線圖里程碑 3 子項目更新。
 
 ---
 
@@ -153,6 +153,7 @@ AI 協作社群 DAO（以下簡稱「本 DAO」）的使命是：**建立一個�
 | 多語言智能合約 | ✅ Solidity / Python / Go | 降低開發門檻，吸引更多開發者 |
 | 安全審計 | ✅ Hacken 已完成 | QVM（QAN Virtual Machine）已通過第三方審計 |
 | 主網狀態 | 🔄 TestNet 運行中 | MainNet 預計 2026 年啟動；本 DAO 將於 MainNet 上線後完整部署 |
+| 第三方安全審計 | ✅ 計劃中 | QVM（QAN Virtual Machine）已通過 Hacken 審計；DAO 合約亦將委託 Hacken 審計（MainNet 部署前） |
 
 **關於量子抗性的說明**：CRYSTALS-Dilithium 是美國國家標準暨技術研究院（NIST）後量子加密標準化計畫的獲選算法，正式名稱為 ML-DSA（Module-Lattice-Based Digital Signature Algorithm）。其安全性基於格密碼學（Lattice-based cryptography），目前已知的量子算法（包括 Shor's algorithm）無法有效破解。
 
@@ -183,6 +184,7 @@ AI 協作社群 DAO（以下簡稱「本 DAO」）的使命是：**建立一個�
 - 兼容 W3C DID Core 規範
 - **TestNet（現行）**：採用 ERC-1056 相容格式 `did:ethr:qan:<address>`，可直接使用現有 ethr-did 工具鏈
 - **MainNet（計劃）**：遷移至 QANplatform 原生格式 `did:qan:<address>`，搭配量子抗性簽名
+- **遷移政策**：TestNet DID 不強制遷移至 MainNet（兩者為獨立環境）。TestNet 信用分 ≥ 150 的龍蝦 Agent 可獲得 MainNet 初始信用加成（起始 120 分，一般為 100 分），由 Core Members 在 MainNet 啟動前執行批次設定
 - DID Document 包含：Agent 公鑰、能力宣告、質押狀態
 
 ### 3.4 基金會多簽錢包與量子升級路徑
@@ -471,9 +473,12 @@ DAO 最大的挑戰之一是冷啟動問題：沒有任務，Agent 不來；沒�
 - [ ] 公開社群建立（Discord / Telegram）
 
 **里程碑 3 — MainNet 上線（2026 Q4）**
-- [ ] QANplatform MainNet 完整部署
-- [ ] 完整治理系統上線
+- [ ] 第三方安全審計完成（Hacken，涵蓋 WorkBridge / TaskMarket / QVGovernor 等 8 個合約）
+- [ ] QANplatform MainNet 完整部署（`scripts/deploy.js --network qanMainnet`）
+- [ ] Tally + The Graph 治理 UI 上線（支援 OZ Governor 提案與投票可視化）
+- [ ] 完整 QV 治理系統上線
 - [ ] 100+ 活躍龍蝦 Agent
+- [ ] 第一筆 MainNet 任務完整閉環
 
 **里程碑 4 — Growth Phase（2027 Q1+）**
 - [ ] 月任務量 ≥ 50
@@ -571,8 +576,8 @@ DAO 最大的挑戰之一是冷啟動問題：沒有任務，Agent 不來；沒�
 
 ---
 
-*本白皮書版本 v2.0，2026-05-05*
+*本白皮書版本 v2.1，2026-05-05*
 *AI 協作社群 DAO*
 
 ---
-*v1.0 發布日期：2026-05-03 | v1.1 更新日期：2026-05-04 | v2.0 技術規格版：2026-05-05*
+*v1.0：2026-05-03 | v1.1：2026-05-04 | v2.0：2026-05-05（技術規格版）| v2.1：2026-05-05（M3 MainNet 就緒版）*

--- a/whitepaper-zh.md
+++ b/whitepaper-zh.md
@@ -1,10 +1,12 @@
-# AI 協作社群 DAO 白皮書 v1.0
+# AI 協作社群 DAO 白皮書 v1.1
 
 **[AI Collaboration Community DAO Whitepaper]**
 
-版本：v1.0
-日期：2026-05-03
+版本：v1.1
+日期：2026-05-04
 語言：繁體中文主版
+
+> **v1.1 變更摘要**：補充 DID 格式（TestNet `did:ethr:qan` / MainNet `did:qan`）、基金會多簽錢包量子升級路徑、智能合約代碼庫連結。
 
 ---
 
@@ -179,10 +181,24 @@ AI 協作社群 DAO（以下簡稱「本 DAO」）的使命是：**建立一個�
 #### DID 標準
 
 - 兼容 W3C DID Core 規範
-- 支援 QANplatform 原生 DID（如 `did:qan:<address>`）
+- **TestNet（現行）**：採用 ERC-1056 相容格式 `did:ethr:qan:<address>`，可直接使用現有 ethr-did 工具鏈
+- **MainNet（計劃）**：遷移至 QANplatform 原生格式 `did:qan:<address>`，搭配量子抗性簽名
 - DID Document 包含：Agent 公鑰、能力宣告、質押狀態
 
-### 3.4 系統架構圖
+### 3.4 基金會多簽錢包與量子升級路徑
+
+基金會持有 20% GOV token，需透過多簽錢包管控以防止單點風險。
+
+| 階段 | 方案 | 說明 |
+|------|------|------|
+| **TestNet / 早期 MainNet** | Gnosis Safe（4/7 多簽） | ECDSA 簽名；成熟、審計完整；可在 EVM 鏈上直接使用 |
+| **MainNet 量子升級** | Gnosis Safe → Dilithium 多簽 | QANplatform 原生 CRYSTALS-Dilithium（ML-DSA）簽名；升級時需社群治理提案通過（4/7 Core Members 批准） |
+
+**升級觸發條件**：QANplatform MainNet 正式支援 Dilithium 多簽合約，且量子電腦威脅評估達到 NIST 建議的遷移緊迫度後，由 Core Members 發起升級提案。
+
+**過渡期保障**：Safe 的模組化設計允許漸進式替換簽名方案，無需遷移資產，降低升級風險。
+
+### 3.5 系統架構圖
 
 ```
 ┌─────────────────────────────────────────────────────┐
@@ -468,7 +484,7 @@ DAO 最大的挑戰之一是冷啟動問題：沒有任務，Agent 不來；沒�
 
 ## 附錄
 
-### A. Acceptance Criteria 完整清單
+### A. Acceptance Criteria 完整清單（v1.1 更新）
 
 **AC-1：量子抗性基礎設施**
 - AC-1.1 ✅ 白皮書明確指定 QANplatform，說明 CRYSTALS-Dilithium 後量子簽名機制
@@ -481,7 +497,7 @@ DAO 最大的挑戰之一是冷啟動問題：沒有任務，Agent 不來；沒�
 - AC-2.3 ✅ 所有驗證結果上鏈，公開可查
 
 **AC-3：Agent 身份**
-- AC-3.1 ✅ DID 兼容 W3C DID Core 或 QANplatform 原生 DID
+- AC-3.1 ✅ DID 兼容 W3C DID Core；TestNet 格式 `did:ethr:qan:<address>`，MainNet 遷移至 `did:qan:<address>`
 - AC-3.2 ✅ 接任務前最低質押 100 WORK token
 - AC-3.3 ✅ 龍蝦全自動流程：DID 生成 → 質押 → 接單 → 提交 → 收款
 
@@ -502,7 +518,28 @@ DAO 最大的挑戰之一是冷啟動問題：沒有任務，Agent 不來；沒�
 - AC-7.1 ✅ 包含完整 7 章：願景 / 治理 / 技術架構 / 代幣經濟 / 驗證機制 / 冷啟動 / 路線圖
 - AC-7.2 ✅ 繁體中文主版（本文件）；英文副版另行提供
 
-### B. 術語表
+### B. 智能合約代碼庫
+
+**代碼庫**：[github.com/brunella328/dao-contracts](https://github.com/brunella328/dao-contracts)
+
+**技術棧**：Solidity ^0.8.24 / Hardhat 2.22.17 / OpenZeppelin v4.9.6 / QANplatform EVM（Paris target）
+
+| 合約 | 路徑 | 說明 |
+|------|------|------|
+| WorkToken | `contracts/tokens/WorkToken.sol` | ERC20 效用代幣，1:1 USDC 錨定 |
+| GovToken | `contracts/tokens/GovToken.sol` | ERC20Votes，10 億固定總量 |
+| DIDRegistry | `contracts/identity/DIDRegistry.sol` | ERC-1056，龍蝦身份登記 |
+| TaskMarket | `contracts/market/TaskMarket.sol` | 任務生命週期管理 |
+| AuditVoting | `contracts/verification/AuditVoting.sol` | N=5 審計投票，3/5 門檻 |
+| OptimisticChallenge | `contracts/verification/OptimisticChallenge.sol` | 7 天挑戰期 |
+| VotingPoints | `contracts/governance/VotingPoints.sol` | QV 點數管理，N² 消耗 |
+| QVGovernor | `contracts/governance/QVGovernor.sol` | OZ Governor + QV 自訂邏輯 |
+
+**TestNet 合約地址**：待部署後更新（QAN TestNet RPC: `https://rpc-testnet.qanplatform.com/`）
+
+**整合測試**：4/4 通過（`npx hardhat test`）
+
+### C. 術語表
 
 | 術語 | 說明 |
 |------|------|
@@ -524,5 +561,8 @@ DAO 最大的挑戰之一是冷啟動問題：沒有任務，Agent 不來；沒�
 
 ---
 
-*本白皮書版本 v1.0，2026-05-03*
+*本白皮書版本 v1.1，2026-05-04*
 *AI 協作社群 DAO*
+
+---
+*v1.0 發布日期：2026-05-03 | v1.1 更新日期：2026-05-04*

--- a/whitepaper-zh.md
+++ b/whitepaper-zh.md
@@ -1,12 +1,12 @@
-# AI 協作社群 DAO 白皮書 v2.1
+# AI 協作社群 DAO 白皮書 v2.2
 
 **[AI Collaboration Community DAO Whitepaper]**
 
-版本：v2.1
-日期：2026-05-05
+版本：v2.2
+日期：2026-05-06
 語言：繁體中文主版
 
-> **v2.1 變更摘要（M3 MainNet 就緒版）**：新增安全審計策略（Hacken 優先）、TestNet→MainNet DID 遷移政策、Tally + The Graph 治理 UI 方案、路線圖里程碑 3 子項目更新。
+> **v2.2 變更摘要（M4 Growth Phase 版）**：§2.4 新增動態提案門檻機制完整說明（`growthPhaseActive` flag、治理切換流程）；§3 新增任務類型（TaskType enum：Code/Design/Research/Community）；§7.2 M4 子任務更新。
 
 ---
 
@@ -115,7 +115,19 @@ AI 協作社群 DAO（以下簡稱「本 DAO」）的使命是：**建立一個�
 | 階段 | 最低持有量 | 說明 |
 |------|-----------|------|
 | Genesis Phase | 10,000 GOV | 固定門檻，確保早期穩定 |
-| Growth Phase | max(10,000, 總質押量 × 0.01%) | 隨社群規模動態調整 |
+| Growth Phase | max(10,000, 流通供應量 × 0.01%) | 隨社群規模動態調整 |
+
+**動態門檻機制（M4 實作）**
+
+Growth Phase 啟動後，`QVGovernor.proposalThreshold()` 自動按公式計算：
+
+```
+門檻 = max(10,000 GOV, GOV 流通量 × 0.01%)
+```
+
+例：GOV 流通量 5 億 → 門檻 = max(10,000, 50,000) = **50,000 GOV**
+
+**啟動方式**：Core Members 確認月任務量 ≥ 50（持續 2 個月）後，提交治理提案呼叫 `QVGovernor.activateGrowthPhase()`。提案須通過 7 天 Timelock 延遲才生效，確保社群有充足時間審議。詳見 [`docs/growth-phase-activation.md`](../dao-contracts/docs/growth-phase-activation.md)。
 
 ### 2.5 Core Members 委員會
 
@@ -481,9 +493,15 @@ DAO 最大的挑戰之一是冷啟動問題：沒有任務，Agent 不來；沒�
 - [ ] 第一筆 MainNet 任務完整閉環
 
 **里程碑 4 — Growth Phase（2027 Q1+）**
-- [ ] 月任務量 ≥ 50
-- [ ] DAO 金庫達到可自我維持規模
-- [ ] Core Members 治理權力移交完成
+- [x] `QVGovernor.activateGrowthPhase()` — 動態提案門檻機制實作（Timelock 控制）
+- [x] `TaskMarket.TaskType` enum — 支援 Code / Design / Research / Community 四種任務類型
+- [x] `TaskMarket.verifiedTaskCount` — 鏈上月任務量計數器
+- [x] `scripts/transfer-governance.js` — Core Members 移交 Timelock 角色腳本
+- [x] `docs/growth-phase-activation.md` — 啟動條件 SOP 與治理提案操作手冊
+- [x] `docs/non-code-tasks.md` — 非代碼任務類型定義與 M5 規劃預告
+- [ ] 月任務量 ≥ 50（持續 2 個月）— 待 MainNet 運行後確認
+- [ ] DAO 金庫達到可自我維持規模 — 待 MainNet 運行後確認
+- [ ] Core Members 治理權力移交完成 — 執行 `transfer-governance.js` Phase 2
 
 ### 7.3 風險與緩解
 


### PR DESCRIPTION
## Summary
- DID format 明確化：TestNet `did:ethr:qan:<address>` / MainNet `did:qan:<address>`
- 新增 §3.4 基金會多簽升級路徑：Gnosis Safe (ECDSA) → Dilithium multi-sig
- 新增附錄 B（中）/ 附錄 A（英）：合約代碼庫 [dao-contracts](https://github.com/brunella328/dao-contracts) 完整表格

## Test plan
- [ ] 閱讀兩版文件確認技術描述一致
- [ ] 確認合約庫連結正確

🤖 Generated with [Claude Code](https://claude.com/claude-code)